### PR TITLE
Prevent bad strings being written

### DIFF
--- a/ref/test_reading.py
+++ b/ref/test_reading.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+import sys
+import tnetstrings
+
+for line in sys.stdin.readlines():
+    try:
+        value, _ = tnetstrings.parse(line)
+        print "succeeded: %s %s" % (type(value), value)
+
+
+    except Exception as err:
+        print "failed: %s" % (err,) 

--- a/ref/tnetstrings.py
+++ b/ref/tnetstrings.py
@@ -1,0 +1,115 @@
+# Note this implementation is more strict than necessary to demonstrate
+# minimum restrictions on types allowed in dictionaries.
+
+def dump(data):
+    if type(data) is long or type(data) is int:
+        out = str(data)
+        return '%d:%s#' % (len(out), out)
+    elif type(data) is float:
+        out = '%f' % data
+        return '%d:%s^' % (len(out), out)
+    elif type(data) is str:
+        return '%d:' % len(data) + data + ',' 
+    elif type(data) is dict:
+        return dump_dict(data)
+    elif type(data) is list:
+        return dump_list(data)
+    elif data == None:
+        return '0:~'
+    elif type(data) is bool:
+        out = repr(data).lower()
+        return '%d:%s!' % (len(out), out)
+    else:
+        assert False, "Can't serialize stuff that's %s." % type(data)
+
+
+def parse(data):
+    payload, payload_type, remain = parse_payload(data)
+
+    if payload_type == '#':
+        value = int(payload)
+    elif payload_type == '}':
+        value = parse_dict(payload)
+    elif payload_type == ']':
+        value = parse_list(payload)
+    elif payload_type == '!':
+        value = payload == 'true'
+    elif payload_type == '^':
+        value = float(payload)
+    elif payload_type == '~':
+        assert len(payload) == 0, "Payload must be 0 length for null."
+        value = None
+    elif payload_type == ',':
+        value = payload
+    else:
+        assert False, "Invalid payload type: %r" % payload_type
+
+    return value, remain
+
+def parse_payload(data):
+    assert data, "Invalid data to parse, it's empty."
+    length, extra = data.split(':', 1)
+    length = int(length)
+
+    payload, extra = extra[:length], extra[length:]
+    assert extra, "No payload type: %r, %r" % (payload, extra)
+    payload_type, remain = extra[0], extra[1:]
+
+    assert len(payload) == length, "Data is wrong length %d vs %d" % (length, len(payload))
+    return payload, payload_type, remain
+
+def parse_list(data):
+    if len(data) == 0: return []
+
+    result = []
+    value, extra = parse(data)
+    result.append(value)
+
+    while extra:
+        value, extra = parse(extra)
+        result.append(value)
+
+    return result
+
+def parse_pair(data):
+    key, extra = parse(data)
+    assert extra, "Unbalanced dictionary store."
+    value, extra = parse(extra)
+
+    return key, value, extra
+
+def parse_dict(data):
+    if len(data) == 0: return {}
+
+    key, value, extra = parse_pair(data)
+    assert type(key) is str, "Keys can only be strings."
+
+    result = {key: value}
+
+    while extra:
+        key, value, extra = parse_pair(extra)
+        result[key] = value
+  
+    return result
+    
+
+
+def dump_dict(data):
+    result = []
+    for k,v in data.items():
+        result.append(dump(str(k)))
+        result.append(dump(v))
+
+    payload = ''.join(result)
+    return '%d:' % len(payload) + payload + '}'
+
+
+def dump_list(data):
+    result = []
+    for i in data:
+        result.append(dump(i))
+
+    payload = ''.join(result)
+    return '%d:' % len(payload) + payload + ']'
+
+

--- a/test_case.sh
+++ b/test_case.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+node -e 'process.stdout.write( require("./tnetstrings.js").dump("\u9999") )' | python ref/test_reading.py

--- a/tests.js
+++ b/tests.js
@@ -15,4 +15,6 @@ var tnetstrings = require('./tnetstrings'),
     assert.deepEqual( tnetstrings.dump(test[1]), test[0] );
 });
 
+assert.throws(function () { tnetstrings.dump('\u9999'); });
+
 console.log('tests done');

--- a/tnetstrings.js
+++ b/tnetstrings.js
@@ -131,10 +131,20 @@ var tnetstrings = {
             var out = data.toString();
             return out.length + ':' + out + '!';
         case 'string':
+            this.assertStringIsSafe(data);
             return data.length + ':' + data + ',';
         case 'object':
             // object in js could be dict, list, null
             return this.dumpObject(data);
+        }
+    },
+
+    assertStringIsSafe: function (str) {
+        var i = str.length;
+
+        while (i--) {
+            if (str.charCodeAt(i) > 127)
+                throw new Error('String is not safe to encode as a bytestring: ' + data);
         }
     }
 };


### PR DESCRIPTION
`string.length` on javascript strings returns the number of characters in the string, but this is not equal to the number of bytes in a string.

Because of this the current implementation will write tnetstrings with incorrect lengths and the reference implementation will choke on them (or worse). 

This pull request checks for strings that are unsafe to encode naively and throws.
